### PR TITLE
Check for environment variable existence

### DIFF
--- a/src/providers/firestore.ts
+++ b/src/providers/firestore.ts
@@ -35,6 +35,9 @@ export const defaultDatabase = '(default)';
 let firestoreInstance;
 
 export function database(database: string = defaultDatabase) {
+  if (!process.env.GCLOUD_PROJECT) {
+    throw new Error('Environment variable GCLOUD_PROJECT is not set.'); 
+  }
   return new DatabaseBuilder(posix.join('projects', process.env.GCLOUD_PROJECT, 'databases', database));
 }
 


### PR DESCRIPTION
`GCLOUD_PROJECT` is sometimes not set (eg when running unit tests locally for HTTP-based functions), which leads to the unhelpful error message:

```
     TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string
      at assertPath (path.js:39:11)
      at Object.join (path.js:1218:7)
      at database (node_modules\firebase-functions\lib\providers\firestore.js:36:45)
      at Object.document (node_modules\firebase-functions\lib\providers\firestore.js:44:12)
```

This change just surfaces a more helpful message.

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->